### PR TITLE
Add warning about comments in real.properties

### DIFF
--- a/docs/administration/security/authentication.md
+++ b/docs/administration/security/authentication.md
@@ -177,6 +177,10 @@ You must change some configuration values to change the authentication module to
 
 Configuring LDAP consists of defining a JAAS config file (e.g. "jaas-ldap.conf"), and changing the server startup script to use this file and use the correct Login Module configuration inside it.
 
+:::warning
+The jaas-ldap.conf file cannot have comments. Adding a `#` character will break parsing in JAAS.
+:::
+
 #### Sync Rundeck profile from LDAP user attributes
 
 You can use LDAP user attributes to update the email, first name, and last name properties of your Rundeck users.


### PR DESCRIPTION
When reconfiguring our rundeck ldap integration I restarted and started receiving 503 errors after login.

The root cause of this was found to be a comment in the realm.properties.  When searching for more information we found documentation of this in the confluent docs: https://docs.confluent.io/5.4.5/control-center/security/c3-auth-ldap.html